### PR TITLE
Add support for translating textContent of element through data-translate.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.6",
+  "version": "0.0.7",
   "name": "tplify",
   "description": "A simple html template compiler plugin for Browserify",
   "main": "index.js",

--- a/src/simpleTranslationProvider.js
+++ b/src/simpleTranslationProvider.js
@@ -1,0 +1,17 @@
+class SimpleTranslationProvider {
+    constructor() {
+        this._dictionary = {};
+    }
+
+    translate(id, element) {
+        if(!this._dictionary[id])
+            return element.textContent;
+        return this._dictionary[id];
+    }
+
+    setDictionary(dictionary) {
+        this._dictionary = dictionary;
+    }
+}
+
+export default new SimpleTranslationProvider();

--- a/src/template.js
+++ b/src/template.js
@@ -1,7 +1,9 @@
-export default class Template {
+import simpleTranslationProvider from './simpleTranslationProvider';
 
-    constructor(dom) {
+export default class Template {
+    constructor(dom, translationProvider = simpleTranslationProvider) {
         this._dom = dom;
+        this._translationProvider = translationProvider;
         this._init();
         this._compile();
     }
@@ -22,6 +24,9 @@ export default class Template {
         });
         this._processAttributes('data-property').forEach(item => {
             this.propertyElements[item.name] = item.value;
+        });
+        this._processAttributes('data-translate').forEach(item => {
+            item.value.textContent = this._translationProvider.translate(item.name, item.value);
         });
         this._childNodes = [].slice.call(this._dom.childNodes, 0);
     }

--- a/test/template-engine/simpleTranslationProvider/simpleTranslationProviderSpec.js
+++ b/test/template-engine/simpleTranslationProvider/simpleTranslationProviderSpec.js
@@ -1,0 +1,26 @@
+import simpleTranslationProvider from '../../../src/simpleTranslationProvider';
+
+describe('simpleTranslationProvider', () => {
+    let sut = simpleTranslationProvider;
+
+    it('should return same text if key is not in dictionary', () => {
+        let key = 'not-existing';
+        let element = {
+            textContent: 'FooBar'
+        };
+        let returned = sut.translate(key, element);
+        expect(returned).to.equal(element.textContent);
+    });
+
+    describe('setDictionary', () => {
+        let key = 'existing-key';
+        let translatedValue = 'BarBaz';
+        let element = {};
+        sut.setDictionary({ [key]: translatedValue });
+
+        it('should return translated text when key exists in dictionary', () => {
+            let returned = sut.translate(key, element);
+            expect(returned).to.equal(translatedValue);
+        });
+    });
+})

--- a/test/template-engine/template/templateSpec.js
+++ b/test/template-engine/template/templateSpec.js
@@ -13,10 +13,11 @@ describe('Template', () => {
     describe('create given named container and 2 named children ', () => {
         let containerElementName = 'container',
             firstElementName = 'first',
+            firstElementTranslateId = 'hello',
             secondElementName = 'second',
             rawTemplate = `
                 <div data-name=${containerElementName}>
-                    <div data-name="${firstElementName}"></div>
+                    <div data-name="${firstElementName}">Hello</div>
                     <div data-name="${secondElementName}"></div>
                 </div>`;
 
@@ -40,7 +41,6 @@ describe('Template', () => {
             let actual = sut.namedElements[secondElementName];
             expect(actual).is.not.undefined;
         });
-
     });
 
     describe('create given 2 elements marked as property on different levels', () => {
@@ -89,7 +89,27 @@ describe('Template', () => {
         });
     });
 
+    describe('create given element with i18n', () => {
+        let translateId = 'hello';
+        let translatedContent = 'Hei';
+        let translationProvider = {
+            translate: function(id, element) {
+                if(id === translateId)
+                    return translatedContent;
+            }
+        };
 
+        let rawTemplate = `<div data-translate="${translateId}">Hello</div>`;
+
+        let dom = document.createElement('div');
+        dom.innerHTML = rawTemplate;
+        let sut = new Template(dom, translationProvider);
+
+        it('translates textContent of elements with data-translate', () => {
+            let actual = dom.children[0].textContent;
+            expect(actual).to.equal(translatedContent);
+        });
+    })
 
     describe('reclaimChildren attached to an external node ', () => {
         let dom = document.createElement('div');

--- a/test/template-engine/template/templateSpec.js
+++ b/test/template-engine/template/templateSpec.js
@@ -13,11 +13,10 @@ describe('Template', () => {
     describe('create given named container and 2 named children ', () => {
         let containerElementName = 'container',
             firstElementName = 'first',
-            firstElementTranslateId = 'hello',
             secondElementName = 'second',
             rawTemplate = `
                 <div data-name=${containerElementName}>
-                    <div data-name="${firstElementName}">Hello</div>
+                    <div data-name="${firstElementName}"></div>
                     <div data-name="${secondElementName}"></div>
                 </div>`;
 


### PR DESCRIPTION
index.js

``` js
var simpleTranslationProvider = require('tplify/dist/simpleTranslationProvider');
simpleTranslationProvider.setDictionary({
    "hello": "Hola",
    "world": "Mundo"
});

var view = require('./helloWorld.tpl.html');
view.activate(document.body);
```

helloWorld.tpl.html

``` html
<div>
    <span data-translate="hello">Hello</span> <span data-translate="world">World</span>!
</div>
```

Result:

``` html
<div>
    <span data-translate="hello">Hola</span> <span data-translate="world">Mundo</span>!
</div>
```
